### PR TITLE
👌 Add ability to localize figure caption

### DIFF
--- a/src/sphinx_subfigure/main.py
+++ b/src/sphinx_subfigure/main.py
@@ -79,7 +79,10 @@ class SubfigureDirective(SphinxDirective):
             elif isinstance(child, nodes.paragraph):
                 if has_caption:
                     raise self.error("Invalid subfigure content (multiple captions)")
-                child.replace_self(nodes.caption(child.rawsource, *child.children))
+                caption = nodes.caption(child.rawsource, *child.children)
+                caption.source = child.source
+                caption.line = child.line
+                child.replace_self(caption)
                 has_caption = True
             else:
                 raise self.error(


### PR DESCRIPTION
Sphinx localization needs node source and line and if it is not present, localization step is skipped.

If the source looks like (MyST markdown)

```markdown
::::{subfigure} A

:::{image} img1.png
:alt: Subfigure caption
:width: 100px
:::

Figure caption
::::
```

Then after running `make gettext`, this `.pot` file is generated
```po
#: ../../index.md:1
msgid "Subfigure caption"
msgstr ""
```


After applying the PR, this `.pot` file is generated
```po
#: ../../index.md:1
msgid "Subfigure caption"
msgstr ""

#: ../../index.md:8
msgid "Figure caption"
msgstr ""
```