### PR TITLE
Remove debug output

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,6 +15,7 @@ python:
 sphinx:
   builder: html
   fail_on_warning: true
+  configuration: docs/conf.py
 
 # Also build PDF & ePub
 formats:

--- a/src/sphinx_subfigure/main.py
+++ b/src/sphinx_subfigure/main.py
@@ -90,7 +90,6 @@ class SubfigureDirective(SphinxDirective):
                     f"item {idx + 1} is neither (line {child.line})"
                 )
 
-        print(number_of_images)
         layout_string = self.arguments[0] if self.arguments else 1
         figure_node["layout"] = {}
         figure_node["layout"]["default"] = self.generate_layout(


### PR DESCRIPTION
A number is printed every time Sphinx runs into a subfigure in the build process. This appears as verbose, and can be confusing without further context.