### PR TITLE
👌 Remove debug output, declare parallel read/write support

### DIFF
--- a/src/sphinx_subfigure/main.py
+++ b/src/sphinx_subfigure/main.py
@@ -9,16 +9,23 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx.application import Sphinx
 from sphinx.util.docutils import SphinxDirective
+from sphinx.util.typing import ExtensionMetadata
 
+from . import __version__
 from .tr_html import setup_html
 from .tr_latex import setup_latex
 
 
-def setup(app: Sphinx) -> None:
+def setup(app: Sphinx) -> ExtensionMetadata:
     """Setup the extension."""
     app.add_directive("subfigure", SubfigureDirective)
     setup_html(app)
     setup_latex(app)
+    return {
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
 
 
 class SubfigureDirective(SphinxDirective):
@@ -104,7 +111,6 @@ class SubfigureDirective(SphinxDirective):
                     f"item {idx + 1} is neither (line {child.line})"
                 )
 
-        print(number_of_images)
         if not number_of_images:
             raise self.error("Invalid subfigure content (no images found)")
         layout_string = self.arguments[0] if self.arguments else 1

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -8,6 +8,8 @@ import pytest
 from bs4 import BeautifulSoup
 from sphinx_pytest.plugin import CreateDoctree
 
+from sphinx_subfigure import __version__
+
 IMAGE_PNG = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAHQAAAB0CAYAAABUmhYnAAAEd0lEQVR4Xu2c0ZLjIAwEk///6GzVvZlspWtWksNRnVcwiGmNwHaS5+v1ej38HKPAU6DHsPy3EIGexVOgh/EUqEBPU+Cw9biHCvQwBQ5bjg4V6GEKHLYcHSrQwxQ4bDk6VKCHKXDYcnSoQA9T4LDllB36fD5vlWR9fUvz0+ve9fp0/O7FU7w0n0CXhBSoDiXTRO06FBKKBLLkLvlGgkTp+UvndPzu/ul46Xq7x2/fQ8kR0wtOBaL+1J6uZ+3fPb5Aw0PRtxOWEkigAr3mCJUMuk9cM45uG3ZvJwel8dN4byW8+r1cgWYPVgRaLIlpwqWCT1cgHbr8skOgYUqkgtHwVYfQKZTiTW8rdCgQFWjtt2Pjty3TGdztOB0aHlosuVcHpglJ+h3nUFow7bE6dDOHCjRN2fBty917qEAF+jEHaI+bTlhK0Nsf/aUBpXtYdXy6noDS9dTePf74oYgWRO3dC6b57k6o7vUJFAh3Cz6dMAIV6FWB9FCQlry1f/ejQXLgt9eX6tXu0DSAtL9APysm0OYHI2mCUgVKxxOoQNOcubc/7XnF5yj3LuYPs5Ud+oc5Ry8R6GEpK1CBjlaMuwcvl1xyBC2I8im9T0xva6pPbtL1V+MjPQW6KEQJRAlAggs0vK2oCibQ4g9+LbnXb96THlQBvl5y0yclqYNQAKgAVGIJQHWPpfjf4uv+bUsagECvClCCkL46VIdecyQtKZRhlKGW3OG3LekeQ0DSBOk+1VLCdbdTAqfzlUuuQFPJe/fM9kORQAV6UYBKJslF11NJS0s8xZO2U3zpeO0lNw2g2+HV8dLbKJov1aMKWKDFfyITKKRsegqmjE7H06FpTRHoRwUoQUnu9pJLh4z0EFMdjwRI46ESWwVC8VK7QMN/TRHookDqCB1Knry261AdmmXMdG86xabzd49H83fP1+5QWkB3e7sg4eu06nra46++4K4uqHp9uyACrSKpXS/Q5kMRnUJruN6vnr7Po/VMn9KrepX3UBKgGmD1UVw6P61HoKmi0F+HfhZIhy766NDhU2F66CEgzQXjQRUjjb8aX7tDaYFpwKkgAi0SSAUXaO0Pjkk/HUoKFQ9p0wm/hjcONC2B6W3B24KKv1ZLx0vzgfQoFsyHQJe3LQINHUEZrUNre6wO1aHLw+AvO5QOHdReLbE0/vSeedyhKBWUDh00XpoAAg2/EkIAqD0FlPYXqEDp3Pix/b8/FKUOIMem7fR6j8Yr0fvlYoEWK4JAw0dplOE6dLnrqH5JrCp4NcMFejPQ6h7RnTAUT/eTKkpYiidtH99D04C6bwvS+QX65W8sUMkVaKgAlcRwuLfuNL5Ah/fQKkC6Pi2JKXB6NEjxUTslKF1P7e17KE1YbRfoZwUFuuijQ4v/l5s6VocOOzQFYv9ZBcoldzY8R08VEGiq2Ob9Bbo5oDQ8gaaKbd5foJsDSsMTaKrY5v0FujmgNDyBpopt3l+gmwNKwxNoqtjm/QW6OaA0PIGmim3eX6CbA0rDE2iq2Ob9Bbo5oDS8H8eCMw7yCzx+AAAAAElFTkSuQmCC"
 )
@@ -65,6 +67,18 @@ def test_build_latex(file_params, sphinx_doctree: CreateDoctree):
     tex = Path(result.builder.outdir).joinpath("test.tex").read_text()
     fig_tex = re.findall(r"\\begin\{figure\}.*\\end\{figure\}", tex, re.DOTALL)[0]
     file_params.assert_expected(fig_tex, rstrip_lines=True)
+
+
+def test_extension_metadata(sphinx_doctree: CreateDoctree):
+    """The extension declares its version and parallel read/write safety."""
+    sphinx_doctree.set_conf({"extensions": ["sphinx_subfigure"]})
+    sphinx_doctree.buildername = "html"
+    sphinx_doctree.srcdir.joinpath("image.png").write_bytes(IMAGE_PNG)
+    result = sphinx_doctree(".. subfigure:: A\n\n   .. image:: image.png\n")
+    extension = result.app.extensions["sphinx_subfigure"]
+    assert extension.version == __version__
+    assert extension.parallel_read_safe is True
+    assert extension.parallel_write_safe is True
 
 
 def test_too_many_images(sphinx_doctree: CreateDoctree):


### PR DESCRIPTION
Fixes #18. Supersedes #19 and #16, which no longer merge cleanly against current `main` (#19's `main.py` hunk now conflicts with the adjacent no-images check from #23, and its `.readthedocs.yml` hunk auto-merges into a duplicated `configuration:` key; #16's `tox.ini` hunk targets config rewritten in #21). Both authors are credited via `Co-authored-by` on the commit.

## Changes

- **Remove the leftover debug `print(number_of_images)`** (from #19, by @andersfagerli) — every build using the directive printed a bare integer to stdout per subfigure.
- **`setup()` now returns the extension metadata** (from #16, by @Bizordec):
  ```python
  return {
      "version": __version__,
      "parallel_read_safe": True,
      "parallel_write_safe": True,
  }
  ```
  Previously the extension appeared as `sphinx_subfigure (unknown version)` in tracebacks (visible in #17's report), and Sphinx treated it as not parallel-safe, blocking `-j auto` parallelization for any project using it. The extension keeps no cross-document state (the layout cache lives on each doctree), so both declarations are correct.
- New test asserting the registered version and parallel flags.

28 tests passing on both sphinx 8.2/docutils 0.21 and sphinx 9.0/docutils 0.22.

After this merges, #19 and #16 can be closed with thanks.

