### PR TITLE
FIX: Reject substitution images clearly

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,9 @@ Or, for a more complex, responsive layout:
 5. Spaces in the layout are ignored, so they can be used for visual alignment.
 6. Additional layouts can be defined with `:layout-sm:`, `:layout-lg:`, `:layout-xl:`, and `:layout-xxl:`, for different screen sizes (HTML only).
 
+Images must use `image` or `figure` directives, or MyST image syntax. Image
+substitutions are not supported inside a `subfigure` directive.
+
 :::{subfigure} AA|BC
 :layout-sm: A|B|C
 :gap: 8px

--- a/src/sphinx_subfigure/main.py
+++ b/src/sphinx_subfigure/main.py
@@ -97,6 +97,13 @@ class SubfigureDirective(SphinxDirective):
                     sub["subfigure_area"] = self._area_identifier(number_of_images)
                     number_of_images += 1
                 child.replace_self(images)
+            elif isinstance(child, nodes.paragraph) and any(
+                isinstance(sub, nodes.substitution_reference) for sub in child
+            ):
+                raise self.error(
+                    "Invalid subfigure content (substitution images are not supported; "
+                    "use image directives or MyST images directly)"
+                )
             elif isinstance(child, nodes.paragraph):
                 if has_caption:
                     raise self.error("Invalid subfigure content (multiple captions)")

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -104,6 +104,11 @@ def test_too_many_images(sphinx_doctree: CreateDoctree):
             "no images found",
             id="no images",
         ),
+        pytest.param(
+            ".. |img| image:: image.png\n\n.. subfigure:: AB\n\n   |img| |img|\n",
+            "substitution images are not supported",
+            id="substitution images",
+        ),
     ],
 )
 def test_invalid_content(sphinx_doctree: CreateDoctree, content: str, message: str):


### PR DESCRIPTION
Closes #25

Substitution references are unresolved when the directive runs and were misread as captions, producing an unrelated content or layout error. Reject them before caption conversion and document the supported image syntax.

Verified with the full 29-test suite on Sphinx 8.2.3 and 9.1.0, pre-commit, and the warning-clean docs build.